### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^6.8.0",
-    "eslint-plugin-eslint-plugin": "^2.2.1",
-    "mocha": "^7.0.0"
+    "eslint": "^7.3.0",
+    "eslint-plugin-eslint-plugin": "^2.3.0",
+    "mocha": "^8.2.1"
   },
   "peerDependencies": {
-    "eslint": "^6.8.0"
+    "eslint": "^7.3.0"
   },
   "files": [
     "rules"


### PR DESCRIPTION
Všiml jsem si že v KBC-UI už máme eslint 7 tak aktualizuji ať to nehlásí problém s peer dependencies. Zároveň upgrade `mocha`, tam se spíš dropovala podpora pro node 8 apod, žádné větší změny.