### PR TITLE
Update dependencies to match kbc-ui

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^7.3.0",
-    "eslint-plugin-eslint-plugin": "^2.3.0",
-    "mocha": "^8.2.1"
+    "eslint": "^8.6.0",
+    "eslint-plugin-eslint-plugin": "^4.1.0",
+    "mocha": "^9.1.3"
   },
   "peerDependencies": {
-    "eslint": "^7.3.0"
+    "eslint": "^8.6.0"
   },
   "files": [
     "rules"


### PR DESCRIPTION
KBC UI má Eslint 8 tak upraveno i zde, ať sedí ty dependencies, ono to při instalaci v kbc-ui pak háže warning že to právě nesedí.

Hodím to pak jako v2